### PR TITLE
Spider Legs!

### DIFF
--- a/meal_recipes.yml
+++ b/meal_recipes.yml
@@ -1,0 +1,2367 @@
+- type: microwaveMealRecipe
+  id: RecipeBun
+  name: bun recipe
+  result: FoodBreadBun
+  time: 5
+  group: Breads
+  solids:
+    FoodDoughSlice: 1 # one third of a standard bread dough recipe
+
+#Bagels
+- type: microwaveMealRecipe
+  id: RecipeBagel
+  name: bagel recipe
+  result: FoodBagel
+  time: 5
+  group: Breads
+  solids:
+    FoodDoughRope: 1 # created by rolling a dough slice.
+
+- type: microwaveMealRecipe
+  id: RecipeBagelPoppy
+  name: poppyseed bagel recipe
+  result: FoodBagelPoppy
+  time: 5
+  group: Breads
+  solids:
+    FoodDoughRope: 1
+    PoppySeeds: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBagelCotton
+  name: cotton bagel recipe
+  result: FoodBagelCotton
+  time: 5
+  group: Moth
+  solids:
+    FoodDoughCottonRope: 1
+
+#Burgers
+
+- type: microwaveMealRecipe
+  id: RecipeAppendixBurger
+  name: appendix burger recipe
+  result: FoodBurgerAppendix
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    OrganHumanAppendix: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBaconBurger
+  name: bacon burger recipe
+  result: FoodBurgerBacon
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatBacon: 1
+    FoodCheeseSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeBaseballBurger
+  name: baseball burger recipe
+  result: FoodBurgerBaseball
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    BaseBallBat: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBearger
+  name: bearger recipe
+  result: FoodBurgerBear
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatBear: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBigBiteBurger
+  name: big bite burger recipe
+  result: FoodBurgerBig
+  time: 15
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeat: 2
+    FoodCheeseSlice: 1
+    FoodTomato: 1
+    FoodOnionSlice: 2
+
+- type: microwaveMealRecipe #Added to metamorph recipes
+  id: RecipeBrainBurger
+  name: brain burger recipe
+  result: FoodBurgerBrain
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    OrganHumanBrain: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCatBurger
+  name: cat burger recipe
+  result: FoodBurgerCat
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeat: 1
+    ClothingHeadHatCatEars: 1
+
+- type: microwaveMealRecipe #Added to metamorph recipes
+  id: RecipeCheeseburger
+  name: cheeseburger recipe
+  result: FoodBurgerCheese
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeat: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe #Added to metamorph recipes
+  id: RecipeChickenSandwich
+  name: chicken sandwich recipe
+  result: FoodBurgerChicken
+  time: 10
+  group: Savory
+  reagents:
+    Mayo: 5
+  solids:
+    FoodBreadBun: 1
+    FoodMeatChicken: 1
+
+- type: microwaveMealRecipe
+  id: RecipeClownBurger
+  name: clownburger recipe
+  result: FoodBurgerClown
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    ClothingMaskClown: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCorgiBurger
+  name: corgi burger recipe
+  result: FoodBurgerCorgi
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatCorgi: 1
+
+- type: microwaveMealRecipe #Added to metamorph recipes
+  id: RecipeCrabBurger
+  name: crab burger recipe
+  result: FoodBurgerCrab
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatCrab: 2
+
+- type: microwaveMealRecipe
+  id: RecipeCrazyHamburger
+  name: crazy hamburger recipe
+  result: FoodBurgerCrazy
+  time: 15
+  group: Savory
+  reagents:
+    OilOlive: 15
+  solids:
+    FoodBreadBun: 1
+    FoodMeat: 2
+    FoodCheeseSlice: 2
+    FoodChiliPepper: 1
+    FoodCabbage: 1
+    CrayonGreen: 1
+    Flare: 1
+
+- type: microwaveMealRecipe #Added to metamorph recipes
+  id: RecipeDuckBurger
+  name: duck sandwich recipe
+  result: FoodBurgerDuck
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatDuck: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeEmpoweredBurger
+  name: empowered burger recipe
+  result: FoodBurgerEmpowered
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    SheetPlasma1: 2
+
+- type: microwaveMealRecipe
+  id: RecipeCarpBurger
+  name: fillet-o-carp burger recipe
+  result: FoodBurgerCarp
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatFish: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeFiveBurger
+  name: five alarm burger recipe
+  result: FoodBurgerFive
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeat: 1
+    FoodChiliPepper: 3
+
+- type: microwaveMealRecipe
+  id: RecipeGhostBurger
+  name: ghost burger recipe
+  result: FoodBurgerGhost
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    Ectoplasm: 1
+
+- type: microwaveMealRecipe
+  id: RecipeHumanBurger
+  name: human burger recipe
+  result: FoodBurgerHuman
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatHuman: 1
+
+- type: microwaveMealRecipe
+  id: RecipeJellyBurger
+  name: jelly burger recipe
+  result: FoodBurgerJelly
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodJellyAmanita: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBurgerMcguffin
+  name: McGuffin recipe
+  result: FoodBurgerMcguffin
+  time: 10
+  group: Savory
+  reagents:
+    Egg: 12
+  solids:
+    FoodBreadBun: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBurgerMcrib
+  name: BBQ rib sandwich recipe
+  result: FoodBurgerMcrib
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMealRibs: 1
+    FoodOnionSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMimeBurger
+  name: mime burger recipe
+  result: FoodBurgerMime
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    ClothingMaskMime: 1
+
+- type: microwaveMealRecipe
+  id: RecipePlainBurger
+  name: plain burger recipe
+  result: FoodBurgerPlain
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeat: 1
+
+- type: microwaveMealRecipe
+  id: RecipeRatBurger
+  name: rat burger recipe
+  result: FoodBurgerRat
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatRat: 1
+
+- type: microwaveMealRecipe
+  id: RecipeRobotBurger
+  name: roburger recipe
+  result: FoodBurgerRobot
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    CapacitorStockPart: 2
+    # i would add steel to this recipe but the microwave explodes
+
+- type: microwaveMealRecipe
+  id: RecipeSoylentBurger
+  name: soylent burger recipe
+  result: FoodBurgerSoy
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodCheeseSlice: 2
+    FoodSoybeans: 2 #replace with soylent green when those become craftable
+
+- type: microwaveMealRecipe
+  id: RecipeSpellBurger
+  name: spell burger recipe
+  result: FoodBurgerSpell
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    ClothingHeadHatWizard: 1
+
+- type: microwaveMealRecipe
+  id: RecipeSuperBiteBurger
+  name: super bite burger recipe
+  result: FoodBurgerSuper
+  time: 25
+  group: Savory
+  reagents:
+    TableSalt: 5
+    Egg: 12
+  solids:
+    FoodBreadBun: 1
+    FoodMeat: 2
+    FoodCheeseSlice: 2
+    FoodTomato: 2
+
+- type: microwaveMealRecipe
+  id: RecipeTofuBurger
+  name: tofu burger recipe
+  result: FoodBurgerTofu
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodTofuSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeXenoburger
+  name: xenoburger recipe
+  result: FoodBurgerXeno
+  time: 10
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    FoodMeatXeno: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMothRoachburger
+  name: mothroachburger recipe
+  result: FoodBurgerMothRoach
+  group: Savory
+  solids:
+    FoodBreadBun: 1
+    MobMothroach: 1
+
+#Breads & Sandwiches
+
+- type: microwaveMealRecipe
+  id: RecipeBananaBread
+  name: banana bread recipe
+  result: FoodBreadBanana
+  time: 15
+  group: LoafCakes
+  solids:
+    FoodDough: 1
+    FoodBanana: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCornbread
+  name: cornbread recipe
+  result: FoodBreadCorn
+  time: 10
+  group: Breads
+  solids:
+    FoodDoughCornmeal: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCreamCheeseBread
+  name: cream cheese bread recipe
+  result: FoodBreadCreamcheese
+  time: 15
+  group: Breads
+  reagents:
+    Milk: 5
+  solids:
+    FoodDough: 1
+    FoodCheeseSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeMeatBread
+  name: meat bread recipe
+  result: FoodBreadMeat
+  time: 15
+  group: Breads
+  solids:
+    FoodDough: 1
+    FoodMeatCutlet: 2
+    FoodCheeseSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeMimanaBread
+  name: mimana bread recipe
+  result: FoodBreadMimana
+  time: 15
+  group: Breads
+  reagents:
+    Nothing: 5
+  solids:
+    FoodDough: 1
+    FoodMimana: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBread
+  name: bread recipe
+  result: FoodBreadPlain
+  time: 10
+  group: Breads
+  solids:
+    FoodDough: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBreadCotton
+  name: cotton bread recipe
+  result: FoodBreadCotton
+  time: 10
+  group: Moth
+  solids:
+    FoodDoughCotton: 1
+
+- type: microwaveMealRecipe
+  id: RecipeSausageBread
+  name: sausage bread recipe
+  result: FoodBreadSausage
+  time: 15
+  group: Breads
+  solids:
+    FoodDough: 1
+    FoodMeat: 1 #replace with sausage
+
+- type: microwaveMealRecipe
+  id: RecipeSpiderMeatBread
+  name: spider meat bread recipe
+  result: FoodBreadMeatSpider
+  time: 15
+  group: Breads
+  solids:
+    FoodDough: 1
+    FoodMeatSpiderCutlet: 2
+    FoodCheeseSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeTofuBread
+  name: tofu bread recipe
+  result: FoodBreadTofu
+  time: 15
+  group: Breads
+  solids:
+    FoodDough: 1
+    FoodTofu: 1
+
+- type: microwaveMealRecipe
+  id: RecipeXenoMeatBread
+  name: xeno meat bread recipe
+  result: FoodBreadMeatXeno
+  time: 15
+  group: Breads
+  solids:
+    FoodDough: 1
+    FoodMeatXenoCutlet: 2
+    FoodCheeseSlice: 2
+
+#Slices Only
+
+- type: microwaveMealRecipe
+  id: RecipeBaguette
+  name: baguette recipe
+  result: FoodBreadBaguette
+  time: 15
+  group: Breads
+  reagents:
+    TableSalt: 5
+    Blackpepper: 5
+  solids:
+    FoodDough: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBaguetteCotton
+  name: baguette recipe
+  result: FoodBreadBaguetteCotton
+  time: 15
+  group: Moth
+  reagents:
+    TableSalt: 5
+    Blackpepper: 5
+  solids:
+    FoodDoughCotton: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBaguetteSword
+  name: baguette sword recipe
+  result: WeaponBaguette
+  secretRecipe: true
+  time: 15
+  group: Secret
+  reagents:
+    TableSalt: 5
+    Blackpepper: 5
+  solids:
+    FoodDough: 1
+    PartRodMetal1: 1
+
+- type: microwaveMealRecipe
+  id: RecipeButteredToast
+  name: buttered toast recipe
+  result: FoodBreadButteredToast
+  time: 5
+  group: Breads
+  solids:
+    FoodBreadPlainSlice: 1
+    FoodButterSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeFrenchToast
+  name: french toast recipe
+  result: FoodBreadFrenchToast
+  time: 5
+  group: Breakfast
+  reagents:
+    Milk: 5
+    Egg: 12
+  solids:
+    FoodBreadPlainSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeGarlicBread
+  name: garlic bread slice recipe
+  result: FoodBreadGarlicSlice
+  time: 5
+  group: Breads
+  solids:
+    FoodBreadPlainSlice: 1
+    FoodGarlic: 1
+    FoodButterSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeJellyToast
+  name: jelly toast recipe
+  result: FoodBreadJellySlice
+  time: 5
+  group: Breads
+  solids:
+    FoodBreadPlainSlice: 1
+    FoodJellyAmanita: 1 #replace with jelly
+
+- type: microwaveMealRecipe
+  id: RecipeMoldyBreadSlice
+  name: moldy bread slice recipe
+  result: FoodBreadMoldySlice
+  time: 5
+  group: Breads
+  solids:
+    FoodBreadPlainSlice: 1
+    FoodFlyAmanita: 1
+
+- type: microwaveMealRecipe
+  id: RecipeTwoBreadSlice
+  name: two slice recipe
+  result: FoodBreadTwoSlice
+  time: 5
+  group: Breads
+  reagents:
+    Wine: 5
+  solids:
+    FoodBreadPlainSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeOnionRings
+  name: onion rings recipe
+  result: FoodOnionRings
+  time: 15
+  group: Savory
+  solids:
+    FoodOnionSlice: 1
+
+#Pizzas TODO: contruction graph based pizza
+- type: microwaveMealRecipe
+  id: RecipeMargheritaPizza
+  name: margherita pizza recipe
+  result: FoodPizzaMargherita
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    FoodCheeseSlice: 1
+    FoodTomato: 4
+
+- type: microwaveMealRecipe
+  id: RecipeMushroomPizza
+  name: mushroom pizza recipe
+  result: FoodPizzaMushroom
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    FoodMushroom: 5
+
+- type: microwaveMealRecipe
+  id: RecipeMeatPizza
+  name: meat pizza recipe
+  result: FoodPizzaMeat
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    FoodMeat: 3
+    FoodCheeseSlice: 1
+    FoodTomato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeVegetablePizza
+  name: vegetable pizza recipe
+  result: FoodPizzaVegetable
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    FoodEggplant: 1
+    FoodCarrot: 1
+    FoodCorn: 1
+    FoodTomato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeHawaiianPizza
+  name: Hawaiian pizza recipe
+  result: FoodPizzaPineapple
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    FoodMeatChickenCutlet: 3
+    FoodPineappleSlice: 5
+
+- type: microwaveMealRecipe
+  id: RecipeDankPizza
+  name: dank pizza recipe
+  result: FoodPizzaDank
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    LeavesCannabis: 2
+    FoodCheeseSlice: 1
+    FoodTomato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDonkpocketPizza
+  name: donk-pocket pizza recipe
+  result: FoodPizzaDonkpocket
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    FoodDonkpocketWarm: 3
+    FoodCheeseSlice: 1
+    FoodTomato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeUraniumPizza
+  name: spicy rock pizza recipe
+  result: FoodPizzaUranium
+  time: 30
+  group: Pizza
+  solids:
+    FoodDoughFlat: 1
+    FoodChiliPepper: 2
+    FoodTomato: 2
+    SheetUranium1: 2
+
+- type: microwaveMealRecipe
+  id: RecipeCottonPizza
+  name: cotton pizza recipe
+  result: FoodPizzaCotton
+  time: 30
+  group: Moth
+  solids:
+    FoodDoughCottonFlat: 1
+    CottonBol: 4
+
+#Italian
+- type: microwaveMealRecipe
+  id: RecipeBoiledSpaghetti
+  name: boiled spaghetti recipe
+  result: FoodNoodlesBoiled
+  time: 15
+  group: Pasta
+  reagents:
+    Flour: 15
+    Egg: 6
+    OilOlive: 5
+
+- type: microwaveMealRecipe
+  id: RecipePastaTomato
+  name: pasta tomato recipe
+  result: FoodNoodles
+  time: 10
+  group: Pasta
+  solids:
+    FoodNoodlesBoiled: 1
+    FoodTomato: 2
+
+- type: microwaveMealRecipe
+  id: RecipeMeatballSpaghetti
+  name: spaghetti & meatballs recipe
+  result: FoodNoodlesMeatball
+  time: 10
+  group: Pasta
+  solids:
+    FoodNoodlesBoiled: 1
+    FoodMeatMeatball: 2
+
+- type: microwaveMealRecipe
+  id: RecipeButterNoodles
+  name: butter noodles recipe
+  result: FoodNoodlesButter
+  time: 10
+  group: Pasta
+  solids:
+    FoodNoodlesBoiled: 1
+    FoodButter: 1
+
+- type: microwaveMealRecipe
+  id: RecipeChowMein
+  name: chow mein recipe
+  result: FoodNoodlesChowmein
+  time: 10
+  group: Pasta
+  reagents:
+    Egg: 6
+  solids:
+    FoodNoodlesBoiled: 1
+    FoodEggplant: 1
+    FoodCarrot: 1
+    FoodCorn: 1
+
+- type: microwaveMealRecipe
+  id: RecipeOatmeal
+  name: oatmeal recipe
+  result: FoodOatmeal
+  time: 15
+  group: Savory
+  reagents:
+    Oats: 15
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBoiledRice
+  name: boiled rice recipe
+  result: FoodRiceBoiled
+  time: 15
+  group: Savory
+  reagents:
+    Rice: 15
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+
+- type: microwaveMealRecipe
+  id: RecipeRicePudding
+  name: rice pudding recipe
+  result: FoodRicePudding
+  time: 15
+  group: Dessert
+  reagents:
+    Rice: 15
+    Milk: 10
+    Sugar: 5
+  solids:
+    FoodBowlBig: 1
+
+- type: microwaveMealRecipe
+  id: RecipeRicePork
+  name: rice and pork recipe
+  result: FoodRicePork
+  time: 15
+  group: Savory
+  solids:
+    FoodRiceBoiled: 1
+    FoodMeatCutlet: 3
+
+- type: microwaveMealRecipe
+  id: RecipeRiceGumbo
+  name: black-eyed gumbo recipe
+  result: FoodRiceGumbo
+  time: 15
+  group: Savory
+  solids:
+    FoodRiceBoiled: 1
+    FoodMeatCutlet: 3
+    FoodChiliPepper: 2
+
+- type: microwaveMealRecipe
+  id: RecipeEggRice
+  name: egg-fried rice recipe
+  result: FoodRiceEgg
+  time: 15
+  group: Savory
+  reagents:
+    Egg: 6
+  solids:
+    FoodRiceBoiled: 1
+    FoodCarrot: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCopypasta
+  name: copypasta recipe
+  result: FoodNoodlesCopy
+  time: 10
+  group: Pasta
+  solids:
+    FoodNoodles: 2
+
+#Soups & Stew
+- type: microwaveMealRecipe
+  id: RecipeBisque
+  name: bisque recipe
+  result: FoodSoupBisque
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    FoodTomato: 1
+    FoodMushroom: 1
+    FoodMeatFish: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMeatballSoup
+  name: meatball soup recipe
+  result: FoodSoupMeatball
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    FoodMeatMeatball: 1
+    FoodCarrot: 1
+    FoodPotato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeNettleSoup
+  name: nettle soup recipe
+  result: FoodSoupNettle
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+    Egg: 6
+  solids:
+    FoodBowlBig: 1
+    Nettle: 1
+    FoodPotato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeEyeballSoup
+  name: eyeball soup recipe
+  result: FoodSoupEyeball
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    OrganHumanEyes: 1
+    FoodCarrot: 1
+    FoodPotato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeAmanitaJelly
+  name: amanita jelly recipe
+  result: FoodJellyAmanita
+  time: 10
+  group: Savory
+  reagents:
+    Water: 5
+    Vodka: 5
+  solids:
+    FoodFlyAmanita: 3
+
+- type: microwaveMealRecipe
+  id: RecipeOnionSoup
+  name: onion soup recipe
+  result: FoodSoupOnion
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    FoodOnionSlice: 5
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMushroomSoup
+  name: mushroom soup recipe
+  result: FoodSoupMushroom
+  time: 10
+  group: Soup
+  reagents:
+    Water: 5
+    Milk: 5
+  solids:
+    FoodBowlBig: 1
+    FoodMushroom: 2
+
+- type: microwaveMealRecipe
+  id: RecipeStewSoup
+  name: stew recipe
+  result: FoodSoupStew
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    FoodMeatCutlet: 3
+    FoodTomato: 1
+    FoodPotato: 1
+    FoodCarrot: 1
+    FoodEggplant: 1
+    FoodMushroom: 1
+
+- type: microwaveMealRecipe
+  id: RecipeTomatoSoup
+  name: tomato soup recipe
+  result: FoodSoupTomato
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    FoodTomato: 2
+
+- type: microwaveMealRecipe
+  id: RecipeTomatoBloodSoup
+  name: tomato blood soup recipe
+  result: FoodSoupTomatoBlood
+  time: 10
+  group: Soup
+  reagents:
+    Blood: 10
+  solids:
+    FoodBowlBig: 1
+    FoodBloodTomato: 2
+
+- type: microwaveMealRecipe
+  id: RecipeWingFangChuSoup
+  name: wing fang chu recipe
+  result: FoodSoupWingFangChu
+  time: 10
+  group: Soup
+  reagents:
+    Soysauce: 5
+  solids:
+    FoodBowlBig: 1
+    FoodMeatXenoCutlet: 2
+
+- type: microwaveMealRecipe
+  id: RecipeWingFangChuSoupSpider
+  name: wing fang chu recipe
+  result: FoodSoupWingFangChu
+  time: 10
+  group: Soup
+  reagents:
+    Soysauce: 5
+  solids:
+    FoodBowlBig: 1
+    FoodMeatSpider: 2
+
+- type: microwaveMealRecipe
+  id: RecipeVegetableSoup
+  name: vegetable soup recipe
+  result: FoodSoupVegetable
+  time: 10
+  group: Soup
+  reagents:
+    Water: 5
+  solids:
+    FoodBowlBig: 1
+    FoodCorn: 1
+    FoodCarrot: 1
+    FoodPotato: 1
+    FoodEggplant: 1
+
+- type: microwaveMealRecipe
+  id: RecipeClownTearsSoup
+  name: clown tears soup recipe
+  result: FoodSoupClown
+  time: 10
+  group: Soup
+  reagents:
+    Water: 10
+  solids:
+    FoodBowlBig: 1
+    FoodBanana: 1
+    MaterialBananium1: 1 # imp - great news op
+    #idk probably replace shard with someting bananium when #14663 merged
+
+- type: microwaveMealRecipe
+  id: RecipeMonkeysDelightSoup
+  name: monkeys delight recipe
+  result: FoodSoupMonkey
+  time: 10
+  group: Soup
+  reagents:
+    Flour: 5
+    TableSalt: 1
+    Blackpepper: 1
+  solids:
+    FoodBowlBig: 1
+    FoodBanana: 1
+    MonkeyCube: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBungoSoup
+  name: bungo soup recipe
+  result: FoodSoupBungo
+  time: 10
+  group: Soup
+  reagents:
+    Water: 5
+  solids:
+    FoodBowlBig: 1
+    FoodBungo: 2
+    FoodChiliPepper: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBoiledSnail
+  name: boiled snail recipe
+  result: FoodMeatSnailCooked
+  time: 5
+  group: Savory
+  reagents:
+    Water: 10
+  solids:
+    FoodMeatSnail: 1
+
+- type: microwaveMealRecipe
+  id: RecipeEscargotSoup
+  name: escargot recipe
+  result: FoodSoupEscargot
+  time: 10
+  group: Soup
+  reagents:
+    Water: 5
+  solids:
+    FoodBowlBig: 1
+    FoodOnionSlice: 1
+    FoodButter: 1
+    FoodMeatSnailCooked: 1
+
+#Pies
+
+- type: microwaveMealRecipe
+  id: RecipeAmanitaPie
+  name: amanita pie recipe
+  result: FoodPieAmanita
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodFlyAmanita: 1
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeApplePie
+  name: apple pie recipe
+  result: FoodPieApple
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodApple: 3
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBaklava
+  name: baklava recipe
+  result: FoodPieBaklava
+  time: 15
+  group: BarsAndCookies
+  solids:
+    FoodDoughPie: 1
+    FoodSnackPistachios: 1 #i'd rather use a botany crop but we don't have nuts yet
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBananaCreamPie
+  name: banana cream pie recipe
+  result: FoodPieBananaCream
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodBanana: 3
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBerryClafoutis
+  name: berry clafoutis recipe
+  result: FoodPieClafoutis
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodBerries: 3
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCherryPie
+  name: cherry pie recipe
+  result: FoodPieCherry
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodCherry: 5
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeFrostyPie
+  name: frosty pie recipe
+  result: FoodPieFrosty
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodChillyPepper: 3
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMeatPie
+  name: meat pie recipe
+  result: FoodPieMeat
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodMeat: 3
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipePumpkinPie
+  name: pumpkin pie recipe
+  result: FoodPiePumpkin
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodPumpkin: 1
+    FoodPlateTin: 1
+
+#- type: microwaveMealRecipe
+#  id: RecipePlumpPie
+#  name: plump pie recipe
+#  result: FoodPiePlump
+#  time: 15
+#  solids:
+#    FoodDoughPie: 1
+#    FoodPlumpHelmet: 3 #a big part of me wants to veto this because the item description is a dick joke but i'll write the placeholder anyway
+#    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeXenoPie
+  name: xeno pie recipe
+  result: FoodPieXeno
+  time: 15
+  group: Pie
+  solids:
+    FoodDoughPie: 1
+    FoodMeatXeno: 3
+    FoodPlateTin: 1
+
+#Tarts
+
+- type: microwaveMealRecipe
+  id: RecipeCocoTart
+  name: chocolate lava tart recipe
+  result: FoodTartCoco
+  time: 15
+  group: Pie
+  reagents:
+    Sugar: 5
+    Milk: 5
+  solids:
+    FoodDoughPie: 1
+    FoodSnackChocolateBar: 3
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeGappleTart
+  name: golden apple streusel tart recipe
+  result: FoodTartGapple
+  time: 15
+  group: Pie
+  reagents:
+    # Gold: 10 # imp - gapple real
+    Sugar: 5
+    Milk: 5
+  solids:
+    FoodDoughPie: 1
+    FoodGoldenApple: 2 # imp
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeGrapeTart
+  name: grape tart recipe
+  result: FoodTartGrape
+  time: 15
+  group: Pie
+  reagents:
+    Sugar: 5
+    Milk: 5
+  solids:
+    FoodDoughPie: 1
+    FoodGrape: 3
+    FoodPlateTin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeMimeTart
+  name: mime tart recipe
+  result: FoodTartMime
+  time: 15
+  group: Pie
+  reagents:
+    Sugar: 5
+    Milk: 5
+  solids:
+    FoodDoughPie: 1
+    FoodMimana: 3
+    FoodPlateTin: 1
+
+#Other
+
+- type: microwaveMealRecipe
+  id: RecipeCubanCarp
+  name: Cuban carp recipe
+  result: FoodMealCubancarp
+  time: 15
+  group: Savory
+  solids:
+    FoodDough: 1
+    FoodCheeseSlice: 2
+    FoodChiliPepper: 1
+    FoodMeatFish: 2
+
+- type: microwaveMealRecipe
+  id: RecipeSashimi
+  name: sashimi recipe
+  result: FoodMealSashimi
+  time: 15
+  group: Savory
+  reagents:
+    TableSalt: 1
+  solids:
+    FoodMeatFish: 2
+
+- type: microwaveMealRecipe
+  id: RecipeMisoColaSoup
+  name: salty sweet misocola soup recipe
+  result: DisgustingSweptSoup
+  time: 15
+  group: Savory
+  reagents:
+    Cola: 5
+  solids:
+    FoodSoupMiso: 1
+
+- type: microwaveMealRecipe
+  id: RecipeLoadedBakedPotato
+  name: loaded baked potato recipe
+  result: FoodMealPotatoLoaded
+  time: 15
+  group: Savory
+  solids:
+    FoodPotato: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeFries
+  name: space fries recipe
+  result: FoodMealFries
+  time: 15
+  group: Savory
+  reagents:
+    TableSalt: 5
+  solids:
+    FoodPotato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCheesyFries
+  name: cheesy fries recipe
+  result: FoodMealFriesCheesy
+  time: 15
+  group: Savory
+  reagents:
+    TableSalt: 5
+  solids:
+    FoodPotato: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCarrotFries
+  name: carrot fries recipe
+  result: FoodMealFriesCarrot
+  time: 15
+  group: Savory
+  reagents:
+    TableSalt: 5
+  solids:
+    FoodCarrot: 1
+
+- type: microwaveMealRecipe
+  id: RecipeNachos
+  name: nachos recipe
+  result: FoodMealNachos
+  time: 10
+  group: Savory
+  reagents:
+    TableSalt: 1
+  solids:
+    FoodDoughTortillaFlat: 1
+    FoodPlateSmall: 1
+
+- type: microwaveMealRecipe
+  id: RecipeNachosCheesy
+  name: cheesy nachos recipe
+  result: FoodMealNachosCheesy
+  time: 10
+  group: Savory
+  reagents:
+    TableSalt: 1
+  solids:
+    FoodCheeseSlice: 1
+    FoodDoughTortillaFlat: 1
+    FoodPlateSmall: 1
+
+- type: microwaveMealRecipe
+  id: RecipeNachosCuban
+  name: cuban nachos recipe
+  result: FoodMealNachosCuban
+  time: 10
+  group: Savory
+  reagents:
+    Ketchup: 5
+  solids:
+    FoodChiliPepper: 1
+    FoodDoughTortillaFlat: 1
+    FoodPlateSmall: 1
+
+- type: microwaveMealRecipe
+  id: RecipePopcorn
+  name: popcorn recipe
+  result: FoodSnackPopcorn
+  time: 20
+  group: Savory
+  solids:
+    FoodCorn: 1
+
+- type: microwaveMealRecipe
+  id: RecipePancake
+  name: pancake recipe
+  result: FoodBakedPancake
+  time: 5
+  group: Breakfast
+  reagents:
+    Flour: 5
+    Milk: 5
+    Egg: 6
+
+- type: microwaveMealRecipe
+  id: RecipeBlueberryPancake
+  name: blueberry pancake recipe
+  result: FoodBakedPancakeBb
+  time: 5
+  group: Breakfast
+  reagents:
+    Flour: 5
+    Milk: 5
+    Egg: 6
+  solids:
+    FoodBerries: 2
+
+- type: microwaveMealRecipe
+  id: RecipeWaffles
+  name: waffle recipe
+  result: FoodBakedWaffle
+  time: 10
+  group: Breakfast
+  reagents:
+    Flour: 5
+    Milk: 5
+    Egg: 6
+    SodaWater: 5
+
+- type: microwaveMealRecipe
+  id: RecipeWaffleSoy
+  name: soy waffle recipe
+  result: FoodBakedWaffleSoy
+  time: 10
+  group: Breakfast
+  reagents:
+    Flour: 5
+    MilkSoy: 5
+    Egg: 6
+    SodaWater: 5
+
+- type: microwaveMealRecipe
+  id: RecipeCookie
+  name: cookie recipe
+  result: FoodBakedCookie
+  time: 5
+  group: BarsAndCookies
+  reagents:
+    Flour: 5
+    Sugar: 5
+  solids:
+    FoodButterSlice: 1
+    FoodSnackChocolateBar: 1
+
+- type: microwaveMealRecipe
+  id: RecipeSugarCookie
+  name: sugar cookie recipe
+  result: FoodBakedCookieSugar
+  time: 5
+  group: BarsAndCookies
+  reagents:
+    Flour: 5
+    Sugar: 10
+  solids:
+    FoodButterSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeRaisinCookie
+  name: raisin cookie recipe
+  result: FoodBakedCookieRaisin
+  time: 5
+  group: BarsAndCookies
+  reagents:
+    Flour: 5
+    Sugar: 5
+  solids:
+    FoodSnackRaisins: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCookieOatmeal
+  name: oatmeal cookie recipe
+  result: FoodBakedCookieOatmeal
+  time: 5
+  group: BarsAndCookies
+  reagents:
+    Oats: 5
+    Sugar: 5
+  solids:
+    FoodButterSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeChocolateChipPancake
+  name: chocolate chip pancake recipe
+  result: FoodBakedPancakeCc
+  time: 5
+  group: BarsAndCookies
+  reagents:
+    Flour: 5
+    Milk: 5
+    Egg: 6
+  solids:
+    FoodSnackChocolateBar: 1
+
+- type: microwaveMealRecipe
+  id: RecipeAppleCake
+  name: apple cake recipe
+  result: FoodCakeApple
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodApple: 3
+
+- type: microwaveMealRecipe
+  id: RecipeCarrotCake
+  name: carrot cake recipe
+  result: FoodCakeCarrot
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodCarrot: 3
+
+- type: microwaveMealRecipe
+  id: RecipeLemonCake
+  name: lemon cake recipe
+  result: FoodCakeLemon
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodLemon: 3
+
+- type: microwaveMealRecipe
+  id: RecipeLemoonCake
+  name: lemoon cake recipe
+  result: FoodCakeLemoon
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodLemoon: 2
+    FoodBerries: 1 #dark colouring
+
+- type: microwaveMealRecipe
+  id: RecipeOrangeCake
+  name: orange cake recipe
+  result: FoodCakeOrange
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodOrange: 3
+
+- type: microwaveMealRecipe
+  id: RecipeBlueberryCake
+  name: blueberry cake recipe
+  result: FoodCakeBlueberry
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodBerries: 3
+
+- type: microwaveMealRecipe
+  id: RecipeLimeCake
+  name: lime cake recipe
+  result: FoodCakeLime
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodLime: 3
+
+- type: microwaveMealRecipe
+  id: RecipeCheeseCake
+  name: cheese cake recipe
+  result: FoodCakeCheese
+  time: 5
+  group: Cake
+  reagents:
+    Cream: 10
+  solids:
+    FoodCakePlain: 1
+    FoodCheeseSlice: 3
+
+- type: microwaveMealRecipe
+  id: RecipePumpkinCake
+  name: pumpkin cake recipe
+  result: FoodCakePumpkin
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodPumpkin: 1
+
+- type: microwaveMealRecipe
+  id: RecipeClownCake
+  name: clown cake recipe
+  result: FoodCakeClown
+  time: 5
+  group: Cake
+  solids:
+    ClothingMaskClown: 1
+    FoodCakePlain: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCake
+  name: cake recipe
+  result: FoodCakePlain
+  time: 15
+  group: Cake
+  solids:
+    FoodCakeBatter: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBirthdayCake
+  name: birthday cake recipe
+  result: FoodCakeBirthday
+  time: 5
+  group: Cake
+  reagents:
+    Cream: 5
+  solids:
+    FoodCakePlain: 1
+
+- type: microwaveMealRecipe
+  id: RecipeChocolateCake
+  name: chocolate cake recipe
+  result: FoodCakeChocolate
+  time: 5
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    FoodSnackChocolateBar: 2
+
+- type: microwaveMealRecipe
+  id: RecipeBrainCake
+  name: brain cake recipe
+  result: FoodCakeBrain
+  time: 15
+  group: Cake
+  solids:
+    FoodCakePlain: 1
+    OrganHumanBrain: 1
+
+- type: microwaveMealRecipe
+  id: RecipeSlimeCake
+  name: slime cake recipe
+  result: FoodCakeSlime
+  time: 5
+  group: Cake
+  reagents:
+    Slime: 15
+  solids:
+    FoodCakePlain: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCatCake
+  name: cat cake recipe
+  result: MobCatCake
+  time: 15
+  group: Cake
+  reagents:
+    Milk: 15
+    Cognizine: 5
+  solids:
+    FoodCakePlain: 1
+    FoodSnackRaisins: 1
+    OrganAnimalHeart: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBreadDog
+  name: bread dog recipe
+  result: MobBreadDog
+  time: 15
+  group: Breads
+  reagents:
+    Cognizine: 5
+  solids:
+    FoodBreadSausage: 1
+    OrganAnimalHeart: 1
+    FoodSpaceshroomCooked: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDumplings
+  name: dumplings recipe
+  result: FoodBakedDumplings
+  time: 15
+  group: Savory
+  reagents:
+    Water: 10
+    UncookedAnimalProteins: 6
+  solids:
+    FoodDoughSlice: 3
+
+- type: microwaveMealRecipe
+  id: RecipeBrownies
+  name: brownie recipe
+  result: FoodBakedBrownieBatch
+  time: 25
+  group: BarsAndCookies
+  reagents:
+    Flour: 15
+    Sugar: 30
+    Egg: 18
+  solids:
+    FoodButter: 2
+    FoodSnackChocolateBar: 2
+
+#Donks i guess
+- type: microwaveMealRecipe
+  id: RecipeWarmDonkpocket
+  name: warm donk pocket recipe
+  result: FoodDonkpocketWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocket: 1
+
+- type: microwaveMealRecipe
+  id: RecipeWarmDankpocket
+  name: warm dank pocket recipe
+  result: FoodDonkpocketDankWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketDank: 1
+
+- type: microwaveMealRecipe
+  id: RecipeWarmDonkpocketSpicy
+  name: warm spicy donk-pocket recipe
+  result: FoodDonkpocketSpicyWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketSpicy: 1
+
+- type: microwaveMealRecipe
+  id: RecipeWarmDonkpocketTeriyaki
+  name: warm teriyaki-pocket recipe
+  result: FoodDonkpocketTeriyakiWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketTeriyaki: 1
+
+- type: microwaveMealRecipe
+  id: RecipeWarmDonkpocketPizza
+  name: warm pizza-pocket recipe
+  result: FoodDonkpocketPizzaWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketPizza: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDonkpocketHonk
+  name: warm honk-pocket recipe
+  result: FoodDonkpocketHonkWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketHonk: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDonkpocketBerry
+  name: warm berry-pocket recipe
+  result: FoodDonkpocketBerryWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketBerry: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDonkpocketStonk
+  name: warm stonk-pocket recipe
+  result: FoodDonkpocketStonkWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketStonk: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDonkpocketCarp
+  name: warm carp-pocket recipe
+  result: FoodDonkpocketCarpWarm
+  time: 5
+  group: Savory
+  solids:
+    FoodDonkpocketCarp: 1
+
+- type: microwaveMealRecipe
+  id: RecipeHotChili
+  name: hot chili recipe
+  result: FoodSoupChiliHot
+  time: 20
+  group: Soup
+  solids:
+    FoodBowlBig: 1
+    FoodChiliPepper: 1
+    FoodMeatCutlet: 1
+    FoodOnionSlice: 1
+    FoodTomato: 1
+
+- type: microwaveMealRecipe
+  id: RecipeColdChili
+  name: cold chili recipe
+  result: FoodSoupChiliCold
+  time: 5
+  group: Soup
+  reagents:
+    Nitrogen: 5
+  solids:
+    FoodSoupChiliHot: 1
+
+- type: microwaveMealRecipe
+  id: RecipeClownTears
+  name: clown's tears recipe
+  result: FoodSoupClown
+  time: 15
+  group: Soup
+  solids:
+    FoodBowlBig: 1
+    FoodOnionSlice: 1
+    FoodTomato: 1
+    BikeHorn: 1
+
+- type: microwaveMealRecipe
+  id: RecipeChiliClown
+  name: chili con carnival recipe
+  result: FoodSoupChiliClown
+  time: 30
+  group: Soup
+  solids:
+    FoodBowlBig: 1
+    FoodChiliPepper: 1
+    FoodMeatCutlet: 1
+    FoodOnionSlice: 1
+    FoodTomato: 1
+    ClothingShoesClown: 1
+
+- type: microwaveMealRecipe
+  id: RecipeQueso
+  name: queso recipe
+  result: FoodMealQueso
+  time: 15
+  group: Soup
+  reagents:
+    Blackpepper: 5 # imp - great news pal Blackpepper is real
+  solids:
+    FoodChiliPepper: 1
+    FoodCheeseSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeRibs
+  name: BBQ ribs recipe
+  result: FoodMealRibs
+  time: 15
+  group: Savory
+  reagents:
+    BbqSauce: 5
+  solids:
+    FoodMeat: 2
+    FoodKebabSkewer: 1
+
+- type: microwaveMealRecipe
+  id: RecipeEnchiladas
+  name: enchiladas recipe
+  result: FoodMealEnchiladas
+  time: 20
+  group: Savory
+  solids:
+    FoodChiliPepper: 2
+    FoodMeatCutlet: 1
+    FoodCorn: 1
+
+# SALADS: These should be moved out of the microwave as soon as possible
+- type: microwaveMealRecipe
+  id: RecipeHerbSalad
+  name: herb salad recipe
+  result: FoodSaladHerb
+  time: 5
+  group: Salad
+  solids:
+    FoodBowlBig: 1
+    FoodAmbrosiaVulgaris: 3
+    FoodApple: 1
+
+- type: microwaveMealRecipe
+  id: RecipeValidSalad
+  name: valid salad recipe
+  result: FoodSaladValid
+  time: 5
+  group: Salad
+  solids:
+    FoodBowlBig: 1
+    FoodAmbrosiaVulgaris: 3
+    FoodPotato: 1
+    FoodMeatMeatball: 1
+
+- type: microwaveMealRecipe
+  id: RecipeColeslaw
+  name: coleslaw recipe
+  result: FoodSaladColeslaw
+  time: 5
+  group: Salad
+  reagents:
+    Vinaigrette: 5
+  solids:
+    FoodBowlBig: 1
+    FoodOnionRed: 1
+    FoodCabbage: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCaesarSalad
+  name: caesar salad recipe
+  result: FoodSaladCaesar
+  time: 5
+  group: Salad
+  reagents:
+    OilOlive: 5
+  solids:
+    FoodBowlBig: 1
+    FoodOnionRedSlice: 1
+    FoodBreadPlainSlice: 1
+    FoodCheeseSlice: 1
+    FoodCabbage: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCitrusSalad
+  name: citrus salad recipe
+  result: FoodSaladCitrus
+  time: 5
+  group: Salad
+  solids:
+    FoodBowlBig: 1
+    FoodOrange: 1
+    FoodLemon: 1
+    FoodLime: 1
+
+- type: microwaveMealRecipe
+  id: RecipeKimchiSalad
+  name: kimchi salad recipe
+  result: FoodSaladKimchi
+  time: 5
+  group: Salad
+  reagents:
+    Vinegar: 5
+  solids:
+    FoodBowlBig: 1
+    FoodCarrot: 1
+    FoodCabbage: 1
+    FoodGarlic: 1
+
+- type: microwaveMealRecipe
+  id: RecipeFruitSalad
+  name: fruit salad recipe
+  result: FoodSaladFruit
+  time: 5
+  group: Salad
+  solids:
+    FoodBowlBig: 1
+    FoodOrange: 1
+    FoodApple: 1
+    FoodGrape: 1
+    FoodWatermelonSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeJungleSalad
+  name: jungle salad recipe
+  result: FoodSaladJungle
+  time: 5
+  group: Salad
+  solids:
+    FoodBowlBig: 1
+    FoodBanana: 1
+    FoodApple: 1
+    FoodGrape: 1
+    FoodWatermelonSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeWatermelonFruitBowlSalad
+  name: watermelon fruit bowl recipe
+  result: FoodSaladWatermelonFruitBowl
+  time: 5
+  group: Salad
+  solids:
+    FoodWatermelon: 1
+    FoodApple: 1
+    FoodBanana: 1
+    FoodLemon: 1
+    FoodOrange: 1
+    FoodAmbrosiaVulgaris: 1
+
+# Muffins
+
+- type: microwaveMealRecipe
+  id: RecipeMuffin
+  name: muffin recipe
+  result: FoodBakedMuffin
+  time: 15
+  group: Dessert
+  solids:
+    FoodPlateMuffinTin: 1
+    FoodDoughSlice: 1
+  reagents:
+    Sugar: 10
+
+- type: microwaveMealRecipe
+  id: RecipeMuffinChocolate
+  name: chocolate muffin recipe
+  result: FoodBakedMuffinChocolate
+  time: 15
+  group: Dessert
+  solids:
+    FoodPlateMuffinTin: 1
+    FoodDoughSlice: 1
+    FoodSnackChocolateBar: 1
+  reagents:
+    Sugar: 10
+
+- type: microwaveMealRecipe
+  id: RecipeMuffinBerry
+  name: berry muffin recipe
+  result: FoodBakedMuffinBerry
+  time: 15
+  group: Dessert
+  solids:
+    FoodPlateMuffinTin: 1
+    FoodDoughSlice: 1
+    FoodBerries: 1
+  reagents:
+    Sugar: 10
+
+- type: microwaveMealRecipe
+  id: RecipeMuffinBanana
+  name: banana muffin recipe
+  result: FoodBakedMuffinBanana
+  time: 15
+  group: Dessert
+  solids:
+    FoodPlateMuffinTin: 1
+    FoodDoughSlice: 1
+    FoodBanana: 1
+  reagents:
+    Sugar: 10
+
+- type: microwaveMealRecipe
+  id: RecipeMuffinCherry
+  name: cherry muffin recipe
+  result: FoodBakedMuffinCherry
+  time: 15
+  group: Dessert
+  solids:
+    FoodPlateMuffinTin: 1
+    FoodDoughSlice: 1
+    FoodCherry: 3
+  reagents:
+    Sugar: 10
+
+# NOT ACTUAL FOOD
+
+- type: microwaveMealRecipe
+  id: RecipeDriedTeaLeaves
+  name: dried tea leaves recipe
+  result: LeavesTeaDried
+  time: 10
+  solids:
+    LeavesTea: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDriedTobacco
+  name: dried tobacco leaves recipe
+  result: LeavesTobaccoDried
+  time: 10
+  group: Medicinal
+  solids:
+    LeavesTobacco: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDriedCannabis
+  name: dried cannabis leaves recipe
+  result: LeavesCannabisDried
+  time: 10
+  group: Medicinal
+  solids:
+    LeavesCannabis: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDriedGreenMarijuana
+  name: dried green marijuana leaves recipe
+  result: LeavesCannabisDried
+  time: 10
+  solids:
+    LeavesGreenMarijuana: 1
+
+- type: microwaveMealRecipe
+  id: RecipeDriedCannabisRainbow
+  name: dried rainbow cannabis leaves recipe
+  result: LeavesCannabisRainbowDried
+  time: 10
+  group: Medicinal
+  solids:
+    LeavesCannabisRainbow: 1
+
+- type: microwaveMealRecipe
+  id: RecipeTrashBakedBananaPeel
+  name: baked banana peel recipe
+  result: TrashBakedBananaPeel
+  time: 5
+  solids:
+    TrashBananaPeel: 1
+
+# Suppermatter
+- type: microwaveMealRecipe
+  id: RecipeSuppermatter
+  name: suppermatter recipe
+  result: FoodCakeSuppermatter
+  time: 30
+  solids:
+    FoodCakeBatter: 2
+  reagents:
+    Sugar: 30
+    Nitrogen: 10
+    Plasma: 10
+
+- type: microwaveMealRecipe
+  id: RecipeFoodBakedChevreChaud
+  name: chevre chaud recipe
+  result: FoodBakedChevreChaud
+  time: 5
+  group: Savory
+  solids:
+    FoodChevreSlice: 1
+    FoodBreadBaguetteSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeFoodBakedChevreChaudCotton
+  name: cotton chevre chaud recipe
+  result: FoodBakedChevreChaudCotton
+  time: 5
+  group: Moth
+  solids:
+    FoodChevreSlice: 1
+    FoodBreadBaguetteCottonSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCannabisButter
+  name: cannabis butter recipe
+  result: FoodCannabisButter
+  time: 15
+  solids:
+    FoodButter: 1
+    LeavesCannabis: 6
+
+- type: microwaveMealRecipe
+  id: RecipeCannabisBrownies
+  name: cannabis brownie recipe
+  result: FoodBakedCannabisBrownieBatch
+  time: 25
+  group: BarsAndCookies
+  reagents:
+    Flour: 15
+    Sugar: 30
+    Egg: 18
+  solids:
+    FoodCannabisButter: 2
+    FoodSnackChocolateBar: 2
+
+- type: microwaveMealRecipe
+  id: RecipeCornInButter
+  name: corn in butter recipe
+  result: FoodMealCornInButter
+  time: 10
+  group: Savory
+  solids:
+    FoodCorn: 1
+    FoodPlate: 1
+    FoodButter: 1
+
+- type: microwaveMealRecipe
+  id: RecipePeaSoup
+  name: pea soup recipe
+  result: FoodSoupPea
+  time: 10
+  group: Soup
+  solids:
+    FoodPeaPod: 2
+    FoodBowlBig: 1
+  reagents:
+    Water: 10
+
+- type: microwaveMealRecipe
+  id: RecipeTacoShell
+  name: taco shell recipe
+  result: FoodTacoShell
+  time: 5
+  group: Breads
+  solids:
+    FoodDoughTortillaFlat: 1 # one third of a standard bread dough recipe
+
+- type: microwaveMealRecipe
+  id: RecipeTacoBeef
+  name: beef taco recipe
+  result: FoodTacoBeef
+  time: 10
+  group: Savory
+  solids:
+    FoodTacoShell: 1
+    FoodMeatCutlet: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeTacoChicken
+  name: chicken taco recipe
+  result: FoodTacoChicken
+  time: 10
+  group: Savory
+  solids:
+    FoodTacoShell: 1
+    FoodMeatChickenCutlet: 1
+    FoodCheeseSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeTacoFish
+  name: fish taco recipe
+  result: FoodTacoFish
+  time: 10
+  group: Savory
+  solids:
+    FoodTacoShell: 1
+    FoodMeatFish: 1
+    FoodOnionSlice: 2
+    FoodTomato: 1
+    FoodCabbage: 1
+
+- type: microwaveMealRecipe
+  id: RecipeTacoRat
+  name: rat taco recipe
+  result: FoodTacoRat
+  time: 10
+  group: Savory
+  solids:
+    FoodTacoShell: 1
+    FoodCheeseSlice: 1
+    FoodMeatRat: 1
+
+- type: microwaveMealRecipe
+  id: RecipeTacoBeefSupreme
+  name: beef taco supreme recipe
+  result: FoodTacoBeefSupreme
+  time: 10
+  group: Savory
+  solids:
+    FoodTacoShell: 1
+    FoodCheeseSlice: 1
+    FoodMeatCutlet: 1
+    FoodTomato: 1
+    FoodCabbage: 1
+    FoodOnionSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeTacoChickenSupreme
+  name: beef taco supreme recipe
+  result: FoodTacoChickenSupreme
+  time: 10
+  group: Savory
+  solids:
+    FoodTacoShell: 1
+    FoodCheeseSlice: 1
+    FoodMeatChickenCutlet: 1
+    FoodTomato: 1
+    FoodCabbage: 1
+    FoodOnionSlice: 2
+
+- type: microwaveMealRecipe
+  id: RecipeCroissant
+  name: croissant recipe
+  result: FoodBakedCroissant
+  time: 5
+  group: Dessert
+  solids:
+    FoodCroissantRaw: 1
+    FoodButterSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeCroissantCotton
+  name: cotton croissant recipe
+  result: FoodBakedCroissantCotton
+  time: 5
+  group: Moth
+  solids:
+    FoodCroissantRawCotton: 1
+    FoodButterSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeThrowingCroissant
+  name: throwing croissant recipe
+  result: WeaponCroissant
+  secretRecipe: true
+  time: 5
+  group: Secret
+  solids:
+    FoodCroissantRaw: 1
+    FoodButterSlice: 1
+    ShardGlass: 1
+
+- type: microwaveMealRecipe
+  id: RecipeInertAnomalyMeat
+  name: inert meat anomaly recipe
+  result: FoodMeatAnomaly
+  time: 5
+  group: Savory
+  solids:
+    AnomalyCoreFleshInert: 1
+
+- type: microwaveMealRecipe
+  id: RecipeAnomalyMeat
+  name: meat anomaly recipe
+  result: FoodMeatAnomaly
+  time: 5
+  group: Savory
+  solids:
+    AnomalyCoreFlesh: 1
+
+- type: microwaveMealRecipe
+  id: RecipeAnomalyMeatCooked
+  name: cooked meat anomaly recipe
+  result: FoodMeatAnomalyCooked
+  time: 5
+  group: Savory
+  solids:
+    FoodMeatAnomaly: 1
+
+- type: microwaveMealRecipe
+  id: RecipeGrilledCheeseSandwich
+  name: grilled cheese sandwich recipe
+  result: FoodBakedGrilledCheeseSandwich
+  time: 10
+  solids:
+    FoodBreadPlainSlice: 2
+    FoodCheeseSlice: 1
+    FoodButterSlice: 1
+
+- type: microwaveMealRecipe
+  id: RecipeBoiledSpiderLeg
+  name: boiled spider leg recipe
+  result: FoodMeatSpiderlegCooked
+  time: 5
+  group: Savory
+  reagents:
+    Water: 10
+  solids:
+    FoodMeatSpiderLeg: 1

--- a/meat.yml
+++ b/meat.yml
@@ -1,0 +1,1872 @@
+# Base
+
+- type: entity
+  parent: FoodInjectableBase
+  id: FoodMeatBase
+  abstract: true
+  components:
+  - type: FlavorProfile
+    flavors:
+      - meaty
+  - type: Sprite
+    sprite: Objects/Consumable/Food/meat.rsi
+  - type: Extractable
+    grindableSolutionName: food
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 5
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 1
+        - ReagentId: Fat
+          Quantity: 5
+  - type: Item
+    size: Tiny
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        # less mass so it can cook faster, a single strip of bacon isnt 5kg
+        density: 1
+        mask:
+        - ItemMask
+        restitution: 0.3  # fite me
+        friction: 0.2
+  # let air cook and freeze meat for cooking and preservation
+  - type: AtmosExposed
+  - type: Temperature
+    currentTemperature: 290
+  # required for cooking to work
+  - type: InternalTemperature
+    thickness: 0.02
+    area: 0.02 # arbitrary number that sounds right for a slab of meat
+  - type: Material
+  - type: PhysicalComposition
+    materialComposition:
+      Meaterial: 300
+
+- type: entity
+  parent: FoodMeatBase
+  id: FoodMeatRawBase
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Perishable
+    # raw meat rots in 5 minutes, get it into the freezer fast
+    rotAfter: 300
+    # don't want meat giving off ammonia only bodies
+    molsPerSecondPerUnitMass: 0
+  - type: RotInto
+    entity: FoodMeatRotten
+    # once it would say bloated, turn into the rotten prototype
+    stage: 1
+
+# bruh
+- type: Tag
+  id: Raw
+
+- type: Tag
+  id: Cooked
+
+- type: Tag
+  id: Cutlet
+
+# Raw
+
+- type: entity
+  name: raw meat
+  parent: FoodMeatRawBase
+  id: FoodMeat
+  description: A slab of raw meat.
+  components:
+  - type: Sprite
+    state: plain
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+        - ReagentId: Fat
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatCutlet
+  - type: InternalTemperature
+    conductivity: 0.43
+  - type: Construction
+    graph: MeatSteak
+    node: start
+    defaultTarget: meat steak
+  - type: Tag
+    tags:
+    - Meat
+
+- type: entity
+  name: raw human meat
+  parent: FoodMeatRawBase
+  id: FoodMeatHuman
+  description: Gross.
+  components:
+  - type: Sprite
+    state: plain
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatCutlet
+
+- type: entity
+  name: raw carp fillet
+  parent: FoodMeatBase
+  # MeatFish?...
+  id: FoodMeatFish
+  description: Your last words being "Wow, exotic!" are not worth it. The taste itself though? Maybe.
+  components:
+  - type: FlavorProfile
+    flavors:
+      #- fishy # imp
+      - carpflesh #imp
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    state: fish
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: CarpoToxin
+          Quantity: 5
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: CarpoToxin
+        Quantity: 5
+  - type: FoodSequenceElement
+    entries:
+      Burger: RawCarpFilletBurger
+
+- type: entity
+  name: raw bacon
+  # bacon is cured so not raw = cant rot
+  parent: FoodMeatBase
+  id: FoodMeatBacon
+  description: A raw piece of bacon.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    state: bacon
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 2
+        - ReagentId: Fat
+          Quantity: 9
+  - type: InternalTemperature
+    conductivity: 0.44
+    thickness: 0.004 # bacon is thin so faster to cook than a steak
+    area: 0.0075 # ~5x15cm
+  - type: Construction
+    graph: Bacon
+    node: start
+    defaultTarget: bacon
+
+- type: entity
+  name: raw bear meat
+  parent: FoodMeatRawBase
+  id: FoodMeatBear
+  description: A very manly slab of raw bear meat.
+  components:
+  - type: Sprite
+    state: bear
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+        - ReagentId: Fat
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatBearCutlet
+  - type: Construction
+    graph: BearSteak
+    node: start
+    defaultTarget: filet migrawr
+
+- type: entity
+  name: raw penguin meat
+  parent: FoodMeatRawBase
+  id: FoodMeatPenguin
+  description: A slab of raw penguin meat. # Can be used as a substitute for fish in recipes. # imp - this literally isnt true lol
+  components:
+  - type: Sprite
+    state: bird
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+        - ReagentId: Fat
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatPenguinCutlet
+  - type: Construction
+    graph: PenguinSteak
+    node: start
+    defaultTarget: cooked penguin
+
+- type: entity
+  name: raw chicken meat
+  parent: FoodMeatRawBase
+  id: FoodMeatChicken
+  description: A slab of raw chicken. Remember to wash your hands!
+  components:
+  - type: Sprite
+    state: bird
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+        - ReagentId: Fat
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatChickenCutlet
+  - type: InternalTemperature
+    conductivity: 0.41
+  - type: Construction
+    graph: ChickenSteak
+    node: start
+    defaultTarget: cooked chicken
+
+- type: entity
+  name: raw duck meat
+  parent: FoodMeatRawBase
+  id: FoodMeatDuck
+  description: A slab of raw duck. Remember to wash your hands!
+  components:
+  - type: Sprite
+    state: bird
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+        - ReagentId: Fat
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatDuckCutlet
+  - type: Construction
+    graph: DuckSteak
+    node: start
+    defaultTarget: cooked duck
+
+- type: entity
+  name: prime-cut corgi meat
+  # can't rot since that would be very bad for syndies
+  parent: [FoodMeatBase, BaseGrandTheftContraband]
+  id: FoodMeatCorgi
+  description: The tainted gift of an evil crime. The meat may be delicious, but at what cost?
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - HighRiskItem
+    - Meat
+  - type: Sprite
+    state: corgi
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 25 # imp
+        reagents:
+        - ReagentId: Bicaridine
+          Quantity: 20
+  - type: StaticPrice
+    price: 750
+  - type: StealTarget
+    stealGroup: FoodMeatCorgi
+
+- type: entity
+  name: raw crab meat
+  parent: FoodMeatRawBase
+  id: FoodMeatCrab
+  description: A pile of raw crab meat.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - crabby
+  - type: Sprite
+    state: crab
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 1
+        - ReagentId: Fat
+          Quantity: 2
+  - type: Construction
+    graph: CrabSteak
+    node: start
+    defaultTarget: cooked crab
+
+- type: entity
+  name: raw goliath meat
+  parent: FoodMeatRawBase
+  id: FoodMeatGoliath
+  description: A slab of goliath meat. It's not very edible now, but it cooks great in lava.
+  components:
+  - type: Sprite
+    state: goliath
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+        - ReagentId: Fat
+          Quantity: 3
+  - type: InternalTemperature
+    thickness: 0.1 # very big, do cook it in lava
+  - type: Construction
+    graph: GoliathSteak
+    node: start
+    defaultTarget: goliath steak
+
+- type: entity
+  name: dragon flesh
+  parent: FoodMeatBase
+  id: FoodMeatDragon
+  description: The dense meat of the space-era apex predator is oozing with its mythical ichor. Ironically, best eaten raw.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    layers:
+    - state: dragon
+    - state: dragon_veins
+      shader: unshaded
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15 # imp
+        reagents:
+        - ReagentId: Ichor
+          Quantity: 10
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Ichor
+        Quantity: 10
+  - type: FoodSequenceElement
+    entries:
+      Burger: DragonBurger
+  - type: FlavorProfile #imp
+    flavors:
+      - carpflesh
+
+- type: entity
+  name: raw rat meat
+  parent: FoodMeatRawBase
+  id: FoodMeatRat
+  description: Prime meat from maintenance!
+  components:
+  - type: Sprite
+    state: plain
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatCutlet
+
+- type: entity
+  name: raw lizard meat
+  parent: FoodMeatRawBase
+  id: FoodMeatLizard
+  description: Delicious dino damage.
+  components:
+  - type: Sprite
+    state: lizard
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+        - ReagentId: Fat
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatLizardCutlet
+  - type: Construction
+    graph: LizardSteak
+    node: start
+    defaultTarget: lizard steak
+
+- type: entity
+  name: raw plant meat
+  parent: FoodMeatBase
+  id: FoodMeatPlant
+  description: All the joys of healthy eating with all the fun of cannibalism.
+  components:
+  - type: Sprite
+    state: plant
+
+- type: entity
+  name: rotten meat
+  parent: FoodMeatBase
+  id: FoodMeatRotten
+  description: Halfway to becoming fertilizer for your garden.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+    - Trash
+    - Recyclable
+  - type: Sprite
+    state: rotten
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+        - ReagentId: GastroToxin
+          Quantity: 4
+        - ReagentId: Fat
+          Quantity: 4
+  - type: FoodSequenceElement # imp
+    entries:
+      Burger: RottenMeatBurger
+
+- type: entity
+  name: raw spider meat
+  parent: FoodMeatRawBase
+  id: FoodMeatSpider
+  description: A slab of spider meat. That's so Kafkaesque.
+  components:
+  - type: Tag
+    tags:
+      - SpiderMeat
+  - type: Sprite
+    state: spider
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 9
+        - ReagentId: Fat
+          Quantity: 9
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatSpiderCutlet
+
+- type: entity
+  name: raw spider leg
+  parent: FoodMeatRawBase
+  id: FoodMeatSpiderLeg
+  description: A still twitching leg of a giant spider... you don't really want to eat this, do you?
+  components:
+  - type: Sprite
+    state: spiderleg
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 10
+        - ReagentId: Fat
+          Quantity: 3
+
+- type: entity
+  name: meatwheat clump
+  parent: FoodMeatBase
+  id: FoodMeatWheat
+  description: This doesn't look like meat, but your standards aren't that high to begin with.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - falsemeat
+  - type: Sprite
+    state: clump
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 1
+
+- type: entity
+  name: raw snake meat
+  parent: FoodMeatBase
+  id: FoodMeatSnake
+  description: A long piece of snake meat, hopefully not poisonous.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    state: snake
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 10
+        - ReagentId: Toxin
+          Quantity: 2
+  - type: FoodSequenceElement # imp
+    entries:
+      Burger: RawSnakeMeatBurger
+
+- type: entity
+  name: raw xeno meat
+  # not raw since acid kills bacteria or something, same as xeno
+  parent: FoodMeatBase
+  id: FoodMeatXeno
+  description: A slab of xeno meat, dripping with acid.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - meaty
+      - acid
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    state: xeno
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 25 # imp
+        reagents:
+        - ReagentId: SulfuricAcid
+          Quantity: 20
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatXenoCutlet
+
+- type: entity
+  name: raw rouny meat
+  # not raw since rouny best
+  parent: FoodMeatBase
+  id: FoodMeatRouny
+  description: A slab of meat from an innocent red friend.
+  components:
+  - type: FlavorProfile
+    flavors:
+    - meaty
+    - acid
+    - lostfriendship
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    state: rouny
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 25 # imp
+        reagents:
+        - ReagentId: SulfuricAcid
+          Quantity: 20
+  - type: Construction
+    graph: RounySteak
+    node: start
+    defaultTarget: rouny steak
+
+- type: entity
+  name: killer tomato meat
+  parent: FoodMeatBase
+  id: FoodMeatTomato
+  description: A slice from a huge tomato.
+  components:
+  - type: Sprite
+    state: tomato
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatTomatoCutlet
+  - type: StaticPrice
+    price: 100
+
+- type: entity
+  name: salami
+  parent: FoodMeatBase
+  id: FoodMeatSalami
+  description: A large tube of salami. Best not to ask what went into it.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    sprite: Objects/Consumable/Food/salami.rsi
+    state: salami
+  - type: SliceableFood
+    slice: FoodMeatSalamiSlice
+  - type: MeleeWeapon
+    wideAnimationRotation: 100
+    damage:
+      types:
+        Blunt: 6
+  - type: Wieldable
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Blunt: 2
+  - type: SolutionContainerManager # imp
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3
+        - ReagentId: Protein
+          Quantity: 3
+
+- type: entity
+  name: meat clown
+  parent: FoodMeatBase
+  id: FoodMeatClown
+  description: A delicious, round piece of meat clown. How horrifying.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - meaty
+      - funny
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    state: clown
+  - type: SliceableFood
+    slice: FoodMeatSalamiSlice
+  - type: SolutionContainerManager # imp
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3
+        - ReagentId: Protein
+          Quantity: 3
+
+- type: entity
+  name: meatball
+  parent: FoodMeatBase
+  id: FoodMeatMeatball
+  description: A raw ball of meat. Meat ball.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Sprite
+    state: meatball
+  - type: SolutionContainerManager # imp
+    solutions:
+      food:
+        maxVol: 20
+        canReact: false # preventing an infinite meatball trick
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+        - ReagentId: Flour
+          Quantity: 5
+        - ReagentId: Egg
+          Quantity: 6
+
+- type: entity
+  name: slimeball
+  parent: FoodMeatBase
+  id: FoodMeatSlime
+  description: A gelatinous shaping of slime jelly.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - slimy
+  - type: Tag
+    tags:
+    - Raw
+    - Meat
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Slime
+        Quantity: 10
+  - type: Sprite
+    state: slime
+  - type: SolutionContainerManager # imp
+    solutions:
+      food:
+        maxVol: 15
+        reagents:
+        - ReagentId: Slime
+          Quantity: 10
+  - type: FoodSequenceElement # imp
+    entries:
+      Burger: SlimeballBurger
+
+- type: entity
+  name: raw snail meat
+  parent: FoodMeatRawBase
+  id: FoodMeatSnail
+  description: Improved with salt.
+  components:
+  - type: Sprite
+    state: snail
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3
+        - ReagentId: Water
+          Quantity: 4 #It makes saline if you add salt!
+
+- type: entity
+  name: anomalous meat mass
+  parent: FoodMeatRawBase
+  id: FoodMeatAnomaly
+  description: An impossibly dense slab of meat. Just looking at it makes you uncomfortable.
+  components:
+  - type: Sprite
+    state: anomalymeat
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 200 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 90
+        - ReagentId: Fat
+          Quantity: 90
+  - type: SliceableFood
+    count: 10
+    sliceTime: 5
+    slice: FoodMeat #That's... So much meat
+  - type: InternalTemperature
+    conductivity: 0.43
+  - type: Construction
+    graph: AnomalyMeatSteak
+    node: start
+    defaultTarget: anomaly steak
+  - type: Tag
+    tags:
+    - Meat
+
+# Cooked
+
+- type: entity
+  parent: FoodBase
+  id: MaterialSmileExtract
+  name: smile extract
+  description: It's a real panacea. But at what cost?
+  components:
+  - type: Extractable
+    grindableSolutionName: food
+  - type: FlavorProfile
+    flavors:
+      - sweet
+  - type: Sprite
+    sprite: Mobs/Aliens/slimes.rsi
+    layers:
+    - map: [ "enum.DamageStateVisualLayers.Base" ]
+      state: rainbow_slime_extract
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 55 # imp
+        reagents:
+        - ReagentId: Omnizine
+          Quantity: 30
+        - ReagentId: Nutriment
+          Quantity: 10
+        - ReagentId: Iron
+          Quantity: 10
+  - type: StaticPrice
+    price: 3000 #It has so much Omnizin in it
+  - type: Tag
+    tags:
+    - Meat
+
+- type: entity
+  name: steak
+  parent: FoodMeatBase
+  id: FoodMeatCooked
+  description: A cooked slab of meat. Smells primal.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+    - Steak
+  - type: Sprite
+    layers:
+    - state: plain-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+        - ReagentId: Protein
+          Quantity: 5
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatCutletCooked
+  - type: Construction
+    graph: MeatSteak
+    node: meat steak
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatSteak
+      Taco: MeatSteak
+
+- type: entity
+  name: bacon
+  parent: FoodMeatBase
+  id: FoodMeatBaconCooked
+  description: A delicious piece of cooked bacon.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: bacon-cooked
+      map: [ "enum.DamageStateVisualLayers.Base" ]
+  - type: RandomSprite
+    available:
+      - enum.DamageStateVisualLayers.Base:
+          bacon-cooked: ""
+          bacon2-cooked: ""
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9 # imp
+        - ReagentId: Protein
+          Quantity: 2 # imp
+  - type: Construction
+    graph: Bacon
+    node: bacon
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatBacon
+      Taco: MeatBacon
+
+- type: entity
+  name: cooked bear
+  parent: FoodMeatBase
+  id: FoodMeatBearCooked
+  description: A well-cooked slab of bear meat. Tough, but tasty with the right sides.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+    - Steak
+  - type: Sprite
+    layers:
+    - state: product-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 2 # imp
+        - ReagentId: Protein
+          Quantity: 5
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatBearCutletCooked
+  - type: Construction
+    graph: BearSteak
+    node: filet migrawr
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatBearBurger
+      Taco: MeatBear
+
+- type: entity
+  name: penguin filet
+  parent: FoodMeatBase
+  id: FoodMeatPenguinCooked
+  description: A cooked filet of penguin. # Can be used as a substitute for fish in recipes. # imp - this literally isnt true lol
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: bird-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9 # imp
+        - ReagentId: Protein
+          Quantity: 9 # imp
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatPenguinCutletCooked
+  - type: Construction
+    graph: PenguinSteak
+    node: cooked penguin
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatPenguinBurger
+      Taco: MeatPenguin
+
+- type: entity
+  name: cooked chicken
+  parent: FoodMeatBase
+  id: FoodMeatChickenCooked
+  description: A cooked piece of chicken. Best used in other recipes.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: bird-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9 # imp
+        - ReagentId: Protein
+          Quantity: 9 # imp
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatChickenCutletCooked
+  - type: Construction
+    graph: ChickenSteak
+    node: cooked chicken
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatChicken
+      Taco: MeatChicken
+
+- type: entity
+  name: fried chicken
+  parent: FoodMeatBase
+  id: FoodMeatChickenFried
+  description: A juicy hunk of chicken meat, fried to perfection.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: chicken-fried
+      map: [ "enum.DamageStateVisualLayers.Base" ]
+  - type: RandomSprite
+    available:
+      - enum.DamageStateVisualLayers.Base:
+          chicken-fried: ""
+          chicken2-fried: ""
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9 # imp
+        - ReagentId: Protein
+          Quantity: 9 # imp
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatChicken
+      Taco: MeatChicken
+
+- type: entity
+  name: cooked duck
+  parent: FoodMeatBase
+  id: FoodMeatDuckCooked
+  description: A cooked piece of duck. Best used in other recipes.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: bird-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9 # imp
+        - ReagentId: Protein
+          Quantity: 9 # imp
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatDuckCutletCooked
+  - type: Construction
+    graph: DuckSteak
+    node: cooked duck
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatDuck
+      Taco: MeatDuck
+
+- type: entity
+  name: cooked crab
+  parent: FoodMeatBase
+  id: FoodMeatCrabCooked
+  description: Some deliciously cooked crab meat.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - crabby
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: crab-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 2 # imp
+        - ReagentId: Protein
+          Quantity: 2 # imp
+  - type: Construction
+    graph: CrabSteak
+    node: cooked crab
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatCrabBurger
+      Taco: MeatCrab
+
+- type: entity
+  name: goliath steak
+  parent: FoodMeatBase
+  id: FoodMeatGoliathCooked
+  description: A delicious, lava cooked steak.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+    - Steak
+  - type: Sprite
+    layers:
+    - state: goliath-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 5
+  - type: Construction
+    graph: GoliathSteak
+    node: goliath steak
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatGoliathBurger
+      Taco: MeatGoliath
+
+- type: entity
+  name: rouny steak
+  parent: FoodMeatBase
+  id: FoodMeatRounyCooked
+  description: Some kill to survive. You on the other hand, kill for fun.
+  components:
+  - type: FlavorProfile
+    flavors:
+    - meaty
+    - lostfriendship
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+    - Steak
+  - type: Sprite
+    layers:
+    - state: rouny-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 25 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+        - ReagentId: Protein
+          Quantity: 10
+  - type: Construction
+    graph: RounySteak
+    node: rouny steak
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatXeno
+      Taco: MeatXeno
+
+- type: entity
+  name: lizard steak
+  parent: FoodMeatBase
+  id: FoodMeatLizardCooked
+  description: Cooked, tough lizard meat.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+    - Steak
+  - type: Sprite
+    layers:
+    - state: lizard-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 9 # imp
+        - ReagentId: Protein
+          Quantity: 9 # imp
+  - type: SliceableFood
+    count: 3
+    slice: FoodMeatLizardCutletCooked
+  - type: Construction
+    graph: LizardSteak
+    node: lizard steak
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatLizardBurger
+      Taco: MeatLizard
+
+- type: entity
+  name: boiled spider leg
+  parent: FoodMeatBase
+  id: FoodMeatSpiderlegCooked
+  description: A giant spider's leg that's still twitching after being cooked. Gross!
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: spiderleg-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 10 # imp
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatSpiderBurger
+      Taco: MeatSpider
+
+- type: entity
+  name: meatball
+  parent: FoodMeatBase
+  id: FoodMeatMeatballCooked
+  description: A cooked meatball. Perfect to add to other dishes... except fruity ones.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    state: meatball-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 11 # imp
+        - ReagentId: Protein
+          Quantity: 5
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatBall
+      Taco: MeatBall
+
+- type: entity
+  name: boiled snail
+  parent: FoodMeatBase
+  id: FoodMeatSnailCooked
+  description: Improved with salt.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: snail-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3
+        - ReagentId: Protein
+          Quantity: 3
+        - ReagentId: Water
+          Quantity: 4 # makes saline if you add salt!
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatSnail
+      Taco: MeatSnail
+
+- type: entity
+  name: anomalous steak
+  parent: FoodMeatBase
+  id: FoodMeatAnomalyCooked
+  description: A gigantic mass of cooked meat. A meal for a dinner party, or someone REALLY hungry.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+  - type: Sprite
+    layers:
+    - state: anomalymeat-cooked #Kinda hard to cook this... thing evenly
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 200 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 90 # imp
+        - ReagentId: Protein
+          Quantity: 90 # imp
+  - type: SliceableFood
+    count: 10
+    sliceTime: 5
+    slice: FoodMeatCooked
+  - type: Construction
+    graph: AnomalyMeatSteak
+    node: anomaly steak
+
+# Cutlets
+
+# Raw
+
+- type: entity
+  name: raw cutlet
+  parent: FoodMeatBase
+  id: FoodMeatCutlet
+  description: A raw meat cutlet.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3 # imp
+  - type: Construction
+    graph: Cutlet
+    node: start
+    defaultTarget: cutlet
+
+- type: entity
+  name: raw bear cutlet
+  parent: FoodMeatBase
+  id: FoodMeatBearCutlet
+  description: A very manly cutlet of raw bear meat.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    layers:
+    - state: cutlet
+    - state: cutlet-alpha
+      color: brown
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3 # imp
+  - type: Construction
+    graph: BearCutlet
+    node: start
+    defaultTarget: bear cutlet
+
+- type: entity
+  name: raw penguin cutlet
+  parent: FoodMeatBase
+  id: FoodMeatPenguinCutlet
+  description: A cutlet of raw penguin meat. # Can be used as a substitute for fish in recipes. # imp - this literally isnt true lol
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet
+    color: white
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3 # imp
+  - type: Construction
+    graph: PenguinCutlet
+    node: start
+    defaultTarget: penguin cutlet
+
+- type: entity
+  name: raw chicken cutlet
+  parent: FoodMeatBase
+  id: FoodMeatChickenCutlet
+  description: A cutlet of raw chicken. Remember to wash your hands!
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet
+    color: white
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3 # imp
+  - type: Construction
+    graph: ChickenCutlet
+    node: start
+    defaultTarget: chicken cutlet
+
+- type: entity
+  name: raw duck cutlet
+  parent: FoodMeatBase
+  id: FoodMeatDuckCutlet
+  description: A cutlet of raw duck. Remember to wash your hands!
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet
+    color: white
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3 # imp
+  - type: Construction
+    graph: DuckCutlet
+    node: start
+    defaultTarget: duck cutlet
+
+- type: entity
+  name: raw lizard cutlet
+  parent: FoodMeatBase
+  id: FoodMeatLizardCutlet
+  description: Delicious dino cutlet.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    layers:
+    - state: cutlet
+      color: green
+    - state: cutlet-alpha
+      color: pink
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3 # imp
+  - type: Construction
+    graph: LizardCutlet
+    node: start
+    defaultTarget: lizard cutlet
+
+- type: entity
+  name: raw spider cutlet
+  parent: FoodMeatBase
+  id: FoodMeatSpiderCutlet
+  description: A cutlet of raw spider meat. So Kafkaesque.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: spidercutlet
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+        - ReagentId: Fat
+          Quantity: 3 # imp
+  - type: Construction
+    graph: SpiderCutlet
+    node: start
+    defaultTarget: spider cutlet
+
+- type: entity
+  name: raw xeno cutlet
+  parent: FoodMeatBase
+  id: FoodMeatXenoCutlet
+  description: A slab of raw xeno meat, dripping with acid.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - meaty
+      - acid
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: xenocutlet
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: SulfuricAcid
+          Quantity: 6.67 # imp
+  - type: Construction
+    graph: XenoCutlet
+    node: start
+    defaultTarget: xeno cutlet
+
+- type: entity
+  name: raw killer tomato cutlet
+  parent: FoodMeatBase
+  id: FoodMeatTomatoCutlet
+  description: A cutlet from a slab of tomato.
+  components:
+  - type: Tag
+    tags:
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: salami-slice
+    color: red
+  - type: StaticPrice
+    price: 30
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatTomatoCutletBurger
+  - type: SolutionContainerManager # imp
+    solutions:
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 1.67
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 0.33
+        - ReagentId: Fat
+          Quantity: 1.67
+
+- type: entity
+  name: salami slice
+  parent: FoodMeatBase
+  id: FoodMeatSalamiSlice
+  description: A slice of cured salami.
+  components:
+  - type: Tag
+    tags:
+    - Raw
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: salami-slice
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 1
+        - ReagentId: Protein
+          Quantity: 1
+  - type: FoodSequenceElement # imp
+    entries:
+      Burger: SalamiBurger
+
+# Cooked
+
+- type: entity
+  name: cutlet
+  parent: FoodMeatBase
+  id: FoodMeatCutletCooked
+  description: A cooked meat cutlet. Needs some seasoning.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 3 # imp
+  - type: Construction
+    graph: Cutlet
+    node: cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: MeatCutlet
+      Taco: MeatCutlet
+
+- type: entity
+  name: bear cutlet
+  parent: FoodMeatBase
+  id: FoodMeatBearCutletCooked
+  description: A very manly cutlet of cooked bear meat.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    layers:
+    - state: cutlet-cooked
+    - state: cutlet-alpha
+      color: brown
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 3 # imp
+  - type: Construction
+    graph: BearCutlet
+    node: bear cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: BearCutletBurger
+      Taco: BearCutlet
+
+- type: entity
+  name: penguin cutlet
+  parent: FoodMeatBase
+  id: FoodMeatPenguinCutletCooked
+  description: A cutlet of cooked penguin meat.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet-cooked
+    color: white
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 3 # imp
+  - type: Construction
+    graph: PenguinCutlet
+    node: penguin cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: PenguinCutletBurger
+      Taco: PenguinCutlet
+
+- type: entity
+  name: chicken cutlet
+  parent: FoodMeatBase
+  id: FoodMeatChickenCutletCooked
+  description: A cutlet of cooked chicken. Remember to wash your hands!
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet-cooked
+    color: white
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 3 # imp
+  - type: Construction
+    graph: ChickenCutlet
+    node: chicken cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: ChickenCutlet
+      Taco: ChickenCutlet
+
+- type: entity
+  name: duck cutlet
+  parent: FoodMeatBase
+  id: FoodMeatDuckCutletCooked
+  description: A cutlet of cooked duck. Remember to wash your hands!
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: cutlet-cooked
+    color: white
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 3 # imp
+  - type: Construction
+    graph: DuckCutlet
+    node: duck cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: DuckCutlet
+      Taco: DuckCutlet
+
+- type: entity
+  name: lizard cutlet
+  parent: FoodMeatBase
+  id: FoodMeatLizardCutletCooked
+  description: Delicious cooked dino cutlet.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    layers:
+    - state: cutlet-cooked
+      color: green
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 3 # imp
+  - type: Construction
+    graph: LizardCutlet
+    node: lizard cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: LizardCutletBurger
+      Taco: LizardCutlet
+
+- type: entity
+  name: spider cutlet
+  parent: FoodMeatBase
+  id: FoodMeatSpiderCutletCooked
+  description: A cutlet of cooked spider meat. Finally edible.
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: spidercutlet-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 3 # imp
+        - ReagentId: Protein
+          Quantity: 3 # imp
+  - type: Construction
+    graph: SpiderCutlet
+    node: spider cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: SpiderCutletBurger
+      Taco: SpiderCutlet
+
+- type: entity
+  name: xeno cutlet
+  parent: FoodMeatBase
+  id: FoodMeatXenoCutletCooked
+  description: A cutlet of cooked xeno, dripping with... tastiness?
+  components:
+  - type: Tag
+    tags:
+    - Cooked
+    - Cutlet
+    - Meat
+  - type: Sprite
+    state: xenocutlet-cooked
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5 # imp
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 1
+        - ReagentId: Protein
+          Quantity: 1
+  - type: Construction
+    graph: XenoCutlet
+    node: xeno cutlet
+  - type: FoodSequenceElement
+    entries:
+      Burger: XenoCutlet
+      Taco: XenoCutlet


### PR DESCRIPTION
Made spiders drop legs upon butchering (+1 for space spiders and +2 for tarantulas, but made tarantulas drop -1 spider meat) and added a microwave recipe for boiled spider legs (1 raw spider leg + 10 water for 5 seconds)

<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes with your own changes.
Make separate pull requests for separate changes. -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

**Changelog**
<!-- Impstation note: we have our own AUTOMATIC changelog now, so please DO use this section! -->
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑
    add: Space spiders and tarantulas now drop raw spider legs, and raw spider legs can now be cooked.

https://github.com/user-attachments/assets/a05c7409-1607-4ba9-8aee-fdf9b9b4518a

